### PR TITLE
Swagger doc updates for furture releases

### DIFF
--- a/dist/interfaces/activityCreateRequest.d.ts
+++ b/dist/interfaces/activityCreateRequest.d.ts
@@ -21,7 +21,7 @@ export interface ActivityCreateRequest extends DelegatedUserIdentification {
      */
     area_name?: string;
     /**
-     * Is whole number between 0 and 4 inclusive
+     * Is whole number between 0 and 10 inclusive
      * If not provided, populated with NSG data related to supplied USRN
      */
     road_category?: number;

--- a/dist/interfaces/baseWorkCreateRequest.d.ts
+++ b/dist/interfaces/baseWorkCreateRequest.d.ts
@@ -26,7 +26,7 @@ export interface BaseWorkCreateRequest extends DelegatedUserIdentification {
      */
     usrn: number;
     /**
-     * Is whole number between 0 and 4 inclusive
+     * Is whole number between 0 and 10 inclusive
      * If not provided, populated with NSG data related to supplied USRN
      */
     road_category?: number;

--- a/dist/interfaces/referenceTypes.d.ts
+++ b/dist/interfaces/referenceTypes.d.ts
@@ -368,7 +368,13 @@ export declare enum AuditEvent {
     non_notifiable_works_record_created = "non_notifiable_works_record_created",
     section_81_works_record_created = "section_81_works_record_created",
     unattributable_works_record_created = "unattributable_works_record_created",
-    upcoming_event = "upcoming_event"
+    upcoming_event = "upcoming_event",
+    sample_inspection_target_created = "sample_inspection_target_created",
+    sample_inspection_target_updated = "sample_inspection_target_updated",
+    sample_inspection_created = "sample_inspection_created",
+    sample_inspection_completed = "sample_inspection_completed",
+    sample_inspection_removed = "sample_inspection_removed",
+    sample_inspection_expired = "sample_inspection_expired"
 }
 export declare enum ASDCode {
     protected_street = 1,

--- a/dist/interfaces/referenceTypes.js
+++ b/dist/interfaces/referenceTypes.js
@@ -401,6 +401,12 @@ var AuditEvent;
     AuditEvent["section_81_works_record_created"] = "section_81_works_record_created";
     AuditEvent["unattributable_works_record_created"] = "unattributable_works_record_created";
     AuditEvent["upcoming_event"] = "upcoming_event";
+    AuditEvent["sample_inspection_target_created"] = "sample_inspection_target_created";
+    AuditEvent["sample_inspection_target_updated"] = "sample_inspection_target_updated";
+    AuditEvent["sample_inspection_created"] = "sample_inspection_created";
+    AuditEvent["sample_inspection_completed"] = "sample_inspection_completed";
+    AuditEvent["sample_inspection_removed"] = "sample_inspection_removed";
+    AuditEvent["sample_inspection_expired"] = "sample_inspection_expired";
 })(AuditEvent = exports.AuditEvent || (exports.AuditEvent = {}));
 var ASDCode;
 (function (ASDCode) {

--- a/src/interfaces/activityCreateRequest.ts
+++ b/src/interfaces/activityCreateRequest.ts
@@ -22,7 +22,7 @@ export interface ActivityCreateRequest extends DelegatedUserIdentification {
    */
   area_name?: string
   /**
-   * Is whole number between 0 and 4 inclusive
+   * Is whole number between 0 and 10 inclusive
    * If not provided, populated with NSG data related to supplied USRN
    */
   road_category?: number

--- a/src/interfaces/baseWorkCreateRequest.ts
+++ b/src/interfaces/baseWorkCreateRequest.ts
@@ -27,7 +27,7 @@ export interface BaseWorkCreateRequest extends DelegatedUserIdentification {
    */
   usrn: number
   /**
-   * Is whole number between 0 and 4 inclusive
+   * Is whole number between 0 and 10 inclusive
    * If not provided, populated with NSG data related to supplied USRN
    */
   road_category?: number

--- a/src/interfaces/referenceTypes.ts
+++ b/src/interfaces/referenceTypes.ts
@@ -397,7 +397,13 @@ export enum AuditEvent {
   non_notifiable_works_record_created = 'non_notifiable_works_record_created',
   section_81_works_record_created = 'section_81_works_record_created',
   unattributable_works_record_created = 'unattributable_works_record_created',
-  upcoming_event = 'upcoming_event'
+  upcoming_event = 'upcoming_event',
+  sample_inspection_target_created = 'sample_inspection_target_created',
+  sample_inspection_target_updated = 'sample_inspection_target_updated',
+  sample_inspection_created = 'sample_inspection_created',
+  sample_inspection_completed = 'sample_inspection_completed',
+  sample_inspection_removed = 'sample_inspection_removed',
+  sample_inspection_expired = 'sample_inspection_expired'
 }
 
 export enum ASDCode {


### PR DESCRIPTION
## Description

feature/SM-5334: update AuditEvent enum with upcoming sample inspection audit events
feature/SM-5549: update allowed range for road_category

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
