### PR TITLE
bug/SM-5458: Set inspection_category property as optional in response models, as it isn't defined if the inspection_type is section_81.

### DIFF
--- a/dist/app/client.js
+++ b/dist/app/client.js
@@ -1,10 +1,9 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/dist/interfaces/inspectionResponse.d.ts
+++ b/dist/interfaces/inspectionResponse.d.ts
@@ -5,7 +5,7 @@ export interface InspectionResponse {
     inspection_reference_number: string;
     inspection_type: InspectionType;
     inspection_start_date: Date;
-    inspection_category: InspectionCategory;
+    inspection_category?: InspectionCategory;
     inspection_outcome: InspectionOutcome;
     defect_details?: string;
     failure_reason_details?: FailureReasonDetailsResponse[];

--- a/dist/interfaces/inspectionSummaryResponse.d.ts
+++ b/dist/interfaces/inspectionSummaryResponse.d.ts
@@ -4,7 +4,7 @@ export interface InspectionSummaryResponse {
     inspection_response_type: InspectionResponseType;
     inspection_reference_number?: string;
     inspection_type: InspectionType;
-    inspection_category: InspectionCategory;
+    inspection_category?: InspectionCategory;
     inspection_outcome?: InspectionOutcome;
     reinspection_date_time?: Date;
 }

--- a/src/interfaces/inspectionResponse.ts
+++ b/src/interfaces/inspectionResponse.ts
@@ -6,7 +6,7 @@ export interface InspectionResponse {
   inspection_reference_number: string
   inspection_type: InspectionType
   inspection_start_date: Date
-  inspection_category: InspectionCategory
+  inspection_category?: InspectionCategory
   inspection_outcome: InspectionOutcome
   defect_details?: string
   failure_reason_details?: FailureReasonDetailsResponse[]

--- a/src/interfaces/inspectionSummaryResponse.ts
+++ b/src/interfaces/inspectionSummaryResponse.ts
@@ -5,7 +5,7 @@ export interface InspectionSummaryResponse {
   inspection_response_type: InspectionResponseType
   inspection_reference_number?: string
   inspection_type: InspectionType
-  inspection_category: InspectionCategory
+  inspection_category?: InspectionCategory
   inspection_outcome?: InspectionOutcome
   reinspection_date_time?: Date
 }


### PR DESCRIPTION
## Description

Set `inspection_category` property as optional in response models, as it isn't defined if the `inspection_type` is `section_81`.

Relates to https://github.com/departmentfortransport/street-manager-api/pull/832.

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [x] Branch named {feature|hotfix|task}/{SM-.*}
- [x] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [x] API definitions updated
- [x] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
