### PR TITLE
SM-6047: HS2 Forward plan fields

### DIFF
--- a/dist/interfaces/forwardPlanCreateRequest.d.ts
+++ b/dist/interfaces/forwardPlanCreateRequest.d.ts
@@ -1,4 +1,4 @@
-import { TrafficManagementType } from './referenceTypes';
+import { TrafficManagementType, HS2HighwayExemption, ForwardPlanWorkType } from './referenceTypes';
 import { PermitASD } from './permitASD';
 import { BaseWorkCreateRequest } from './baseWorkCreateRequest';
 export interface ForwardPlanCreateRequest extends BaseWorkCreateRequest {
@@ -23,4 +23,12 @@ export interface ForwardPlanCreateRequest extends BaseWorkCreateRequest {
     works_location_description: string;
     /** Must consist of 3 positive whole numbers */
     workstream_prefix?: string;
+    /** Required if promoter_swa_code = '7374' */
+    hs2_work_type?: ForwardPlanWorkType;
+    /** Required if promoter_swa_code = '7374' */
+    hs2_in_act_limits?: boolean;
+    /** Date must occur today or a date in the future */
+    hs2_consultation_requested_response_date?: Date;
+    /** Required if hs2_work_type = 'hs2_highway_works' and hs2_in_act_limits = true */
+    hs2_highway_exemption?: HS2HighwayExemption;
 }

--- a/dist/interfaces/forwardPlanResponse.d.ts
+++ b/dist/interfaces/forwardPlanResponse.d.ts
@@ -1,5 +1,5 @@
 import { ForwardPlanSummaryResponse } from './forwardPlanSummaryResponse';
-import { TrafficManagementType } from './referenceTypes';
+import { TrafficManagementType, HS2HighwayExemption, ForwardPlanWorkType } from './referenceTypes';
 import { PermitASD } from './permitASD';
 export interface ForwardPlanResponse extends ForwardPlanSummaryResponse {
     promoter_organisation: string;
@@ -24,4 +24,8 @@ export interface ForwardPlanResponse extends ForwardPlanSummaryResponse {
     additional_info?: string;
     forward_plan_asds?: PermitASD[];
     cancelled_reason?: string;
+    hs2_in_act_limits?: boolean;
+    hs2_consultation_requested_response_date?: Date;
+    hs2_highway_exemption?: HS2HighwayExemption;
+    hs2_works_type?: ForwardPlanWorkType;
 }

--- a/dist/interfaces/referenceTypes.d.ts
+++ b/dist/interfaces/referenceTypes.d.ts
@@ -471,3 +471,7 @@ export declare enum PaymentMethod {
     cash = "cash",
     cheque = "cheque"
 }
+export declare enum ForwardPlanWorkType {
+    planned = "planned",
+    hs2_highway_works = "hs2_highway_works"
+}

--- a/dist/interfaces/referenceTypes.js
+++ b/dist/interfaces/referenceTypes.js
@@ -512,3 +512,8 @@ var PaymentMethod;
     PaymentMethod["cash"] = "cash";
     PaymentMethod["cheque"] = "cheque";
 })(PaymentMethod = exports.PaymentMethod || (exports.PaymentMethod = {}));
+var ForwardPlanWorkType;
+(function (ForwardPlanWorkType) {
+    ForwardPlanWorkType["planned"] = "planned";
+    ForwardPlanWorkType["hs2_highway_works"] = "hs2_highway_works";
+})(ForwardPlanWorkType = exports.ForwardPlanWorkType || (exports.ForwardPlanWorkType = {}));

--- a/src/interfaces/forwardPlanCreateRequest.ts
+++ b/src/interfaces/forwardPlanCreateRequest.ts
@@ -1,4 +1,4 @@
-import { TrafficManagementType } from './referenceTypes'
+import { TrafficManagementType, HS2HighwayExemption, ForwardPlanWorkType } from './referenceTypes'
 import { PermitASD } from './permitASD'
 import { BaseWorkCreateRequest } from './baseWorkCreateRequest'
 
@@ -24,4 +24,12 @@ export interface ForwardPlanCreateRequest extends BaseWorkCreateRequest {
   works_location_description: string
   /** Must consist of 3 positive whole numbers */
   workstream_prefix?: string
+  /** Required if promoter_swa_code = '7374' */
+  hs2_work_type?: ForwardPlanWorkType
+  /** Required if promoter_swa_code = '7374' */
+  hs2_in_act_limits?: boolean
+  /** Date must occur today or a date in the future */
+  hs2_consultation_requested_response_date?: Date
+  /** Required if hs2_work_type = 'hs2_highway_works' and hs2_in_act_limits = true */
+  hs2_highway_exemption?: HS2HighwayExemption
 }

--- a/src/interfaces/forwardPlanResponse.ts
+++ b/src/interfaces/forwardPlanResponse.ts
@@ -1,5 +1,5 @@
 import { ForwardPlanSummaryResponse } from './forwardPlanSummaryResponse'
-import { TrafficManagementType } from './referenceTypes'
+import { TrafficManagementType, HS2HighwayExemption, ForwardPlanWorkType } from './referenceTypes'
 import { PermitASD } from './permitASD'
 
 export interface ForwardPlanResponse extends ForwardPlanSummaryResponse {
@@ -25,4 +25,8 @@ export interface ForwardPlanResponse extends ForwardPlanSummaryResponse {
   additional_info?: string
   forward_plan_asds?: PermitASD[]
   cancelled_reason?: string
+  hs2_in_act_limits?: boolean
+  hs2_consultation_requested_response_date?: Date
+  hs2_highway_exemption?: HS2HighwayExemption
+  hs2_works_type?: ForwardPlanWorkType
 }

--- a/src/interfaces/referenceTypes.ts
+++ b/src/interfaces/referenceTypes.ts
@@ -509,3 +509,8 @@ export enum PaymentMethod {
   cash = 'cash',
   cheque = 'cheque'
 }
+
+export enum ForwardPlanWorkType {
+  planned = 'planned',
+  hs2_highway_works = 'hs2_highway_works'
+}


### PR DESCRIPTION
## Description

Add HS2 fields to forward plan create request and response 

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
