### PR TITLE
[stable] feature/SM-6036: add hs2 fields to PermitAlterationCreateRequest

### DIFF
--- a/dist/interfaces/permitCreateRequest.d.ts
+++ b/dist/interfaces/permitCreateRequest.d.ts
@@ -5,14 +5,7 @@ export interface PermitCreateRequest extends PermitRequest {
     workstream_prefix?: string;
     /** Required if promoter_swa_code = '7374' */
     hs2_in_act_limits?: boolean;
-    /** Date must occur today or a date in the future */
-    hs2_consultation_requested_response_date?: Date;
     /** Required if work_type = 'hs2_highway_works' and hs2_in_act_limits = true */
     hs2_highway_exemption?: HS2HighwayExemption;
-    /** Array Max length 2 items
-     * Array values must be valid email addresses
-     * Array values max length 100 characters
-     */
-    hs2_highway_emails?: string[];
     is_covid_19_response?: boolean;
 }

--- a/dist/interfaces/permitRequest.d.ts
+++ b/dist/interfaces/permitRequest.d.ts
@@ -89,4 +89,11 @@ export interface PermitRequest extends DelegatedUserIdentification {
     additional_contact_number?: string;
     /** Max length 100 characters */
     additional_contact_email?: string;
+    /** Date must occur today or a date in the future */
+    hs2_consultation_requested_response_date?: Date;
+    /** Array Max length 2 items
+     * Array values must be valid email addresses
+     * Array values max length 100 characters
+     */
+    hs2_highway_emails?: string[];
 }

--- a/src/interfaces/permitCreateRequest.ts
+++ b/src/interfaces/permitCreateRequest.ts
@@ -6,14 +6,7 @@ export interface PermitCreateRequest extends PermitRequest {
   workstream_prefix?: string
   /** Required if promoter_swa_code = '7374' */
   hs2_in_act_limits?: boolean
-  /** Date must occur today or a date in the future */
-  hs2_consultation_requested_response_date?: Date
   /** Required if work_type = 'hs2_highway_works' and hs2_in_act_limits = true */
   hs2_highway_exemption?: HS2HighwayExemption
-  /** Array Max length 2 items
-   * Array values must be valid email addresses
-   * Array values max length 100 characters
-   */
-  hs2_highway_emails?: string[]
   is_covid_19_response?: boolean
 }

--- a/src/interfaces/permitRequest.ts
+++ b/src/interfaces/permitRequest.ts
@@ -90,4 +90,11 @@ export interface PermitRequest extends DelegatedUserIdentification {
   additional_contact_number?: string
   /** Max length 100 characters */
   additional_contact_email?: string
+  /** Date must occur today or a date in the future */
+  hs2_consultation_requested_response_date?: Date
+  /** Array Max length 2 items
+   * Array values must be valid email addresses
+   * Array values max length 100 characters
+   */
+  hs2_highway_emails?: string[]
 }


### PR DESCRIPTION
## Description

Move fields from PermitCreateRequest to PermitRequest as this is share by both
the create permit endpoint and the creapte permit alteration endpoint

Fields that have been moved:
 - hs2_consultation_requested_response_date
 - hs2_highway_emails

latest api: https://github.com/departmentfortransport/street-manager-api/pull/880
latest client: https://github.com/departmentfortransport/street-manager-client/pull/284

stable client:  https://github.com/departmentfortransport/street-manager-client/pull/288
stable api: https://github.com/departmentfortransport/street-manager-api-stable/pull/23

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
